### PR TITLE
Configuração do appsettings.json para receber o jwt

### DIFF
--- a/StockApp.API/appsettings.json
+++ b/StockApp.API/appsettings.json
@@ -1,6 +1,12 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Data Source=sqlicomalab.database.windows.net;Initial Catalog=stockapp_db_icoma;User ID=victoricoma;Password=Gordinho123;Connect Timeout=30;Encrypt=True;TrustServerCertificate=False;ApplicationIntent=ReadWrite;MultiSubnetFailover=False"
+    "DefaultConnection": "Data Source=sqlgabrielf.database.windows.net;User ID=gabrielf;Password=GFpl301004@#$%;Connect Timeout=30;Encrypt=True;Trust Server Certificate=False;Application Intent=ReadWrite;Multi Subnet Failover=False"
+  },
+  "JWT": {
+    "Secret": "Gwi-News-Prod",
+    "Issuer": "https://localhost:7189/swagger/index.html",
+    "Audience": "https://gwinews-e715f.web.app/",
+    "ExpireMinutes": 60
   },
   "Logging": {
     "LogLevel": {


### PR DESCRIPTION
Entrega da tarefa: Configuração do AppSettings para JWT

Descrição:
- [ ] Configuração do appsettings.json para JWT, criando um Secret personalizado, Issuer como a url do stock app api quando inicializado e Audience como a url gwinews-e715f;
- [ ] Alteração da Connection String para o banco de dados azure sqlgabrielf.